### PR TITLE
Fix nameplate data leaking across same-name mobs

### DIFF
--- a/modules/nameplates.lua
+++ b/modules/nameplates.lua
@@ -1149,7 +1149,7 @@ nameplates.OnCreate = function(frame)
 	local isGrayLevel = levelDifficultyColor.r == 0.5 and levelDifficultyColor.g == 0.5 and levelDifficultyColor.b == 0.5
 	local class, ulevel, elite, player, guild = GetUnitData(name, true)
 	local target = plate.istarget
-	local mouseover = UnitExists("mouseover")
+	local mouseover = UnitExists("mouseover") and plate.original.glow:IsShown() or nil
 	local unitstr = target and "target" or mouseover and "mouseover" or nil
 	--local red, green, blue = plate.original.healthbar:GetStatusBarColor()
 	--local unittype = GetUnitType(red, green, blue) or "ENEMY_NPC"
@@ -2100,6 +2100,21 @@ nameplates.OnCreate = function(frame)
 		  if superwow_active then
 			cast, nameSubtext, text, texture, startTime, endTime, isTradeSkill = UnitCastingInfo(nameplate.parent:GetName(1))
 			if not cast then channel, nameSubtext, text, texture, startTime, endTime, isTradeSkill = UnitChannelInfo(nameplate.parent:GetName(1)) end
+		  end
+
+		  -- without SuperWoW, casts are tracked by mob name only, so all plates
+		  -- sharing a name would incorrectly show the same castbar; restrict
+		  -- castbar display to target/mouseover or unambiguous (single) plates
+		  if not superwow_active and (cast or channel) and not target and not mouseover then
+			for other_parent in pairs(registry) do
+			  if other_parent ~= nameplate.parent and other_parent:IsVisible() then
+				local other_np = other_parent.nameplate
+				if other_np and other_np.original and other_np.original.name:GetText() == name then
+				  cast, channel = nil, nil
+				  break
+				end
+			  end
+			end
 		  end
 
 		  if not cast and not channel then


### PR DESCRIPTION

#### Problem

When multiple mobs with the same name have active nameplates on screen, all plates incorrectly display data from a
single unit. This affects castbars, debuffs, creature type, class, race, power bars, and combat status — they all
appear on every same-name plate instead of only the relevant one.

#### Root Causes

1. OnDataChanged mouseover leak (line 1152)

UnitExists("mouseover") was used without verifying which plate was actually being moused over. This caused all
non-target plates sharing the mouseover unit's name to receive unitstr = "mouseover", populating them with that
unit's full data. Fixed by adding the plate.original.glow:IsShown() check, matching the already-correct pattern in 
OnUpdate.

2. OnUpdate castbar name collision (lines 2096–2097)

libcast.db is keyed by mob name (parsed from chat messages like "Goblin begins to cast Fireball"). Without SuperWoW
GUIDs, all same-name plates displayed the same castbar. Fixed by restricting castbar display to target/mouseover
plates, or plates whose name is unique among all visible nameplates.

#### Notes

 - Neither fix affects SuperWoW users, where GUID-based lookups already handle disambiguation correctly.
 - This is an inherent limitation of vanilla WoW's lack of unique unit IDs — when multiple same-name mobs exist and 
none is targeted/moused-over, we can't determine which specific mob is casting, so we hide the castbar rather than 
show false positives on all plates.